### PR TITLE
feat: add basic portfolio site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# hubfolio
+# Hubfolio
+
+Un simple site de portfolio statique contenant une présentation, des projets et des informations de contact.
+
+## Développement
+
+Installer les dépendances :
+
+```bash
+npm ci
+```
+
+Lancer les scripts de vérification :
+
+```bash
+npm run lint && npm test
+```
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mon Portfolio</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Mon Portfolio</h1>
+      <nav>
+        <a href="#about">À propos</a>
+        <a href="#projects">Projets</a>
+        <a href="#contact">Contact</a>
+      </nav>
+    </header>
+    <main>
+      <section id="about">
+        <h2>À propos</h2>
+        <p>Bienvenue sur mon portfolio. Je suis développeur web passionné.</p>
+      </section>
+      <section id="projects">
+        <h2>Projets</h2>
+        <ul>
+          <li>Projet 1 - description rapide.</li>
+          <li>Projet 2 - description rapide.</li>
+          <li>Projet 3 - description rapide.</li>
+        </ul>
+      </section>
+      <section id="contact">
+        <h2>Contact</h2>
+        <p>Vous pouvez me contacter à l'adresse <a href="mailto:exemple@example.com">exemple@example.com</a>.</p>
+      </section>
+    </main>
+    <footer>
+      <p>&copy; 2024 Mon Portfolio</p>
+    </footer>
+  </body>
+</html>
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "hubfolio",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hubfolio",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "hubfolio",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "lint": "echo 'Aucun lint configure'",
+    "test": "echo 'Aucun test'"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,33 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+header {
+  background: #333;
+  color: #fff;
+  padding: 1rem;
+}
+
+nav a {
+  color: #fff;
+  margin-right: 1rem;
+  text-decoration: none;
+}
+
+main {
+  padding: 1rem;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #f4f4f4;
+}
+


### PR DESCRIPTION
## Summary
- add simple static portfolio web page
- set up minimal npm project with placeholder lint/test scripts
- document development instructions

## Testing
- `npm run lint && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b02c36309083328719a5d6cd02304e